### PR TITLE
fix: 'sidebar' and 'tray' deprecated issue

### DIFF
--- a/lua/user/nvim-dap.lua
+++ b/lua/user/nvim-dap.lua
@@ -99,25 +99,27 @@ dapui.setup({
 		edit = "e",
 		repl = "r",
 	},
-	sidebar = {
-		-- You can change the order of elements in the sidebar
-		elements = {
-			-- Provide as ID strings or tables with "id" and "size" keys
-			{
-				id = "scopes",
-				size = 0.25, -- Can be float or integer > 1
+	layouts = {
+		{
+			-- You can change the order of elements in the layout
+			elements = {
+				-- Provide as ID strings or tables with "id" and "size" keys
+				{
+					id = "scopes",
+					size = 0.25, -- Can be float or integer > 1
+				},
+				{ id = "breakpoints", size = 0.25 },
+				{ id = "stacks", size = 0.25 },
+				{ id = "watches", size = 0.25 },
 			},
-			{ id = "breakpoints", size = 0.25 },
-			{ id = "stacks", size = 0.25 },
-			{ id = "watches", size = 0.25 },
+			size = 40,
+			position = "left", -- Can be "left", "right", "top", "bottom"
 		},
-		size = 40,
-		position = "left", -- Can be "left", "right", "top", "bottom"
-	},
-	tray = {
-		elements = { "repl" },
-		size = 10,
-		position = "bottom", -- Can be "left", "right", "top", "bottom"
+		{
+			elements = { "repl" },
+			size = 10,
+			position = "bottom", -- Can be "left", "right", "top", "bottom"
+		},
 	},
 	floating = {
 		max_height = nil, -- These can be integers or a float between 0 and 1.


### PR DESCRIPTION
I use my neovim according your config repo and updated all the plugins today (including `dap` related plugins), then when I open it, this error shows: 

`The 'sidebar' and 'tray' options are deprecated. Please use 'layouts' instead.`

So I did some quick fix according to the hints and it works fine now in my two mac.